### PR TITLE
Rotas para redefinição de senha de alunos e professores pelo administrador

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 from flask import Flask
 from dotenv import load_dotenv
-from src.utils.extensions import db, jwt, migrate
+from src.utils.extensions import db, jwt, migrate, ma
 from flask_cors import CORS
 import os
 
@@ -15,6 +15,7 @@ def create_app():
 
     db.init_app(app)
     migrate.init_app(app, db)
+    ma.init_app(app)
     jwt.init_app(app)
 
     CORS(app, resources={r"/*": {"origins": "*"}})

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from flask import Flask
 from dotenv import load_dotenv
 from src.utils.extensions import db, jwt, migrate, ma
@@ -12,6 +14,7 @@ def create_app():
     app.config['SQLALCHEMY_DATABASE_URI'] = os.getenv('SQLALCHEMY_DATABASE_URI')
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
     app.config['JWT_SECRET_KEY'] = os.getenv('JWT_SECRET_KEY')
+    app.config["JWT_ACCESS_TOKEN_EXPIRES"] = timedelta(hours=2)
 
     db.init_app(app)
     migrate.init_app(app, db)

--- a/src/routes/admin.py
+++ b/src/routes/admin.py
@@ -1,11 +1,15 @@
+import os
+
 from dotenv import load_dotenv
 from flask import Blueprint, jsonify, request, send_file
 from flask_jwt_extended import jwt_required, get_jwt_identity
-from src.utils.models import Admin, Projeto, Professor, Edital
-from ..services.admin_service import AdminService
+
+from src.utils.models import Admin, Projeto, Professor, Edital, Aluno
 from src.utils.utils import role_required
-import os
-from uuid import UUID
+from ..services.admin_service import AdminService
+from ..services.auth_service import AuthService, ph
+from ..utils.extensions import db
+from ..utils.schemas import professor_schema, aluno_schema
 
 load_dotenv()
 
@@ -225,11 +229,7 @@ def detalhes_projeto(projeto_id):
 @role_required('Admin')
 def listar_professores_pendentes():
     try:
-        current_user = get_jwt_identity()
-        print(f"JWT Identity: {current_user}")
-
         professor_list = AdminService.listar_professor_pendentes()
-        print(f"Professores Pendentes: {professor_list}")
 
         if not professor_list:
             return jsonify({"message": "Nenhum professor pendente encontrado."}), 200
@@ -247,7 +247,6 @@ def listar_professores_pendentes():
         return jsonify(professores_data), 200
 
     except Exception as e:
-        print(f"Erro ao listar professores pendentes: {e}")
         return jsonify({"message": "Erro ao listar professores pendentes", "error": str(e)}), 500
 
 
@@ -255,10 +254,6 @@ def listar_professores_pendentes():
 @jwt_required()
 @role_required('Admin')
 def listar_professores_aprovados():
-    current_user = get_jwt_identity()
-    if current_user['role'] != 'Admin':
-        return jsonify({"message": "Access denied"}), 403
-
     try:
         professor_list = AdminService.listar_professores_aprovados()
         professores_data = [
@@ -274,11 +269,6 @@ def listar_professores_aprovados():
 @jwt_required()
 @role_required('Admin')
 def aprovar_projeto(projeto_id):
-    current_user = get_jwt_identity()
-
-    if current_user['role'] != 'Admin':
-        return jsonify({"message": "Access denied"}), 403
-
     try:
         projeto_aprovado = AdminService.aprovar_projeto(str(projeto_id))
 
@@ -303,11 +293,6 @@ def aprovar_projeto(projeto_id):
 @jwt_required()
 @role_required('Admin')
 def rejeitar_projeto(projeto_id):
-    current_user = get_jwt_identity()
-
-    if current_user['role'] != 'Admin':
-        return jsonify({"message": "Access denied"}), 403
-
     try:
         projeto_rejeitado = AdminService.rejeitar_projeto(projeto_id)
 
@@ -327,3 +312,77 @@ def rejeitar_projeto(projeto_id):
 
     except Exception as e:
         return jsonify({"message": "Erro ao rejeitar o projeto", "error": str(e)}), 400
+
+
+@bp.route("/api/professores", methods=["GET"])
+@jwt_required()
+@role_required("Admin")
+def listar_professores():
+    professores = db.scalars(db.select(Professor).order_by(Professor.id)).all()
+    if not professores:
+        return jsonify({"message": "Nenhum professor encontrado"}), 404
+
+    return professor_schema.dump(professores, many=True), 200
+
+
+@bp.route("/api/professor/<uuid:professor_id>/senha", methods=["PUT"])
+@jwt_required()
+@role_required("Admin")
+def redefinir_senha_professor(professor_id):
+    try:
+        json = request.json
+        if "password" not in json:
+            return jsonify({"message": "Senha não informada"}), 400
+
+        senha = json['password']
+        if not AuthService.is_strong_password(senha):
+            return jsonify({"message": "A senha deve conter ao menos 8 caracteres, incluindo letras e números"}), 400
+
+        professor: Professor = db.scalar(db.select(Professor).where(Professor.id == professor_id))
+        if not professor:
+            return jsonify({"message": "Professor não encontrado"}), 404
+
+        professor.password = ph.hash(senha)
+        db.session.commit()
+
+        return jsonify({"message": "Senha redefinida com sucesso"}), 200
+
+    except Exception as e:
+        return jsonify({"message": "Erro interno no servidor", "error": str(e)}), 500
+
+
+@bp.route("/api/alunos", methods=["GET"])
+@jwt_required()
+@role_required("Admin")
+def listar_alunos():
+    alunos = db.scalars(db.select(Aluno).order_by(Aluno.id)).all()
+    if not alunos:
+        return jsonify({"message": "Nenhum aluno encontrado"}), 404
+    
+    return aluno_schema.dump(alunos, many=True), 200
+
+
+@bp.route("/api/aluno/<uuid:aluno_id>/senha", methods=["PUT"])
+@jwt_required()
+@role_required("Admin")
+def redefinir_senha_aluno(aluno_id):
+    try:
+        json = request.json
+        if "password" not in json:
+            return jsonify({"message": "Senha não informada"}), 400
+
+        senha = json['password']
+        if not AuthService.is_strong_password(senha):
+            return jsonify({"message": "A senha deve conter ao menos 8 caracteres, incluindo letras e números"}), 400
+
+        aluno: Professor = db.scalar(db.select(Aluno).where(Aluno.id == aluno_id))
+        if not aluno:
+            return jsonify({"message": "Aluno não encontrado"}), 404
+
+        aluno.password = ph.hash(senha)
+        db.session.commit()
+
+        return jsonify({"message": "Senha redefinida com sucesso"}), 200
+
+    except Exception as e:
+        return jsonify({"message": "Erro interno no servidor", "error": str(e)}), 500

--- a/src/utils/extensions.py
+++ b/src/utils/extensions.py
@@ -1,7 +1,9 @@
-from flask_sqlalchemy import SQLAlchemy
-from flask_migrate import Migrate
 from flask_jwt_extended import JWTManager
+from flask_marshmallow import Marshmallow
+from flask_migrate import Migrate
+from flask_sqlalchemy import SQLAlchemy
 
 db = SQLAlchemy()
 migrate = Migrate()
+ma = Marshmallow()
 jwt = JWTManager()

--- a/src/utils/schemas.py
+++ b/src/utils/schemas.py
@@ -1,5 +1,9 @@
 from marshmallow import Schema, fields, validate
 
+from src.utils.extensions import ma
+from src.utils.models import Professor, Aluno
+
+
 class ProjetoSchema(Schema):
     vagas = fields.Integer(required=True, validate=validate.Range(min=1, error="O número de vagas deve ser ao menos 1"))
     titulacao = fields.String(required=True, validate=validate.Length(min=1, error="Titulação é obrigatória"))
@@ -19,13 +23,18 @@ class ProjetoSchema(Schema):
     referencias = fields.String(required=True, validate=validate.Length(min=1, error="Referências são obrigatórias"))
     termos = fields.Boolean(required=True, error_messages={"required": "É necessário aceitar os termos"})
 
-class AlunoSchema(Schema):
-    id = fields.UUID()
-    nome = fields.Str()
-    matricula = fields.Int()
-    curso = fields.Str()
-    data_ingresso = fields.DateTime()
-    telefone = fields.Str()
-    email = fields.Str()
-    permissao = fields.Str()
 
+class AlunoSchema(ma.SQLAlchemyAutoSchema):
+    class Meta:
+        model = Aluno
+        load_instance = True
+
+
+class ProfessorSchema(ma.SQLAlchemyAutoSchema):
+    class Meta:
+        model = Professor
+        load_instance = True
+
+
+aluno_schema: Schema = AlunoSchema()
+professor_schema: Schema = ProfessorSchema()


### PR DESCRIPTION
Adicionadas novas rotas à API para permitir que administradores listem professores e alunos, bem como redefinam suas senhas. Todas as rotas requerem autenticação JWT e permissão de Administrador.

```GET admin/api/professores```
```PUT admin/api/professor/<uuid:professor_id>/senha```
```GET admin/api/alunos```
```PUT admin/api/aluno/<uuid:aluno_id>/senha```

Requisitos:
- Deve receber um JSON contendo a nova senha
- A senha deve ser enviada no campo "password" dentro do JSON
- A senha precisa ter pelo menos 8 caracteres, incluindo letras e números

Também foi aumentado o tempo de expiração do token de acesso JWT foi para 2 hora.